### PR TITLE
docs: update README and BappDescription

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,7 +1,7 @@
 <p>This is an extension for Burp Suite designed to help you launch <a href="https://portswigger.net/research/http-desync-attacks">HTTP Request Smuggling</a> attacks. It supports scanning for Request Smuggling vulnerabilities, and also aids exploitation by handling cumbersome offset-tweaking for you.</p>
 
 <h4>Use</h4>
-<p>Right click on a request and click 'Launch Smuggle probe', then watch the extension's output pane.
+<p>Right-click on a request and click 'Extensions -> HTTP Request Smuggler -> Smuggle probe', then watch the extension's output pane.
 
 For more advanced use watch the <a href="https://portswigger.net/research/http-desync-attacks">video</a>, and check out the <a href="https://github.com/PortSwigger/http-request-smuggler">documentation</a>.</p>
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ This is an extension for Burp Suite designed to help you launch [HTTP Request Sm
 This extension should not be confused with [Burp Suite HTTP Smuggler](https://github.com/nccgroup/BurpSuiteHTTPSmuggler), which uses similar techniques but is focused exclusively bypassing WAFs.
 
 ### Install
-The easiest way to install this is in Burp Suite, via `Extender -> BApp Store`.
+The easiest way to install this is in Burp Suite, via `Extensions -> BApp Store`.
 
-If you prefer to load the jar manually, in Burp Suite (community or pro), use `Extender -> Extensions -> Add` to load `build/libs/http-request-smuggler-all.jar`
+If you prefer to load the jar manually, in Burp Suite (community or pro), use `Extensions -> Add` to load `build/libs/http-request-smuggler-all.jar`
 
 ### Compile
-[Turbo Intruder](https://github.com/PortSwigger/turbo-intruder) is a dependency of this project, add it to the root of this source tree as `turbo-intruder-all.jar`
 
 Build using:
 
@@ -18,14 +17,14 @@ Linux: `./gradlew build fatjar`
 
 Windows: `gradlew.bat build fatjar`
 
-Grab the output from `build/libs/desynchronize-all.jar`
+Grab the output from `build/libs/http-request-smuggler-all.jar`
 
 ### Use
-Right click on a request and click `Launch Smuggle probe`, then watch the extension's output pane under `Extender->Extensions->HTTP Request Smuggler`
+Right-click on a request and click `Extensions -> HTTP Request Smuggler -> Smuggle probe`, then watch the extension's Output pane under `Extensions->HTTP Request Smuggler`
 
 If you're using Burp Pro, any findings will also be reported as scan issues.
 
-If you right click on a request that uses chunked encoding, you'll see another option marked `Launch Smuggle attack`. This will open a Turbo Intruder window in which you can try out various attacks by editing the `prefix` variable.
+If you right-click on a request that uses chunked encoding, you'll see another option marked `Launch Smuggle attack`. This will open a Turbo Intruder window in which you can try out various attacks by editing the `prefix` variable.
 
 For more advanced use watch the [video](https://portswigger.net/blog/http-desync-attacks).
 
@@ -33,12 +32,12 @@ For more advanced use watch the [video](https://portswigger.net/blog/http-desync
 
 We've released a collection of [free online labs to practise against](https://portswigger.net/web-security/request-smuggling). Here's how to use the tool to solve the first lab - [HTTP request smuggling, basic CL.TE vulnerability](https://portswigger.net/web-security/request-smuggling/lab-basic-cl-te):
 
-1. Use the Extender->BApp store tab to install the 'HTTP Request Smuggler' extension.
-2. Load the lab homepage, find the request in the proxy history, right click and select 'Launch smuggle probe', then click 'OK'.
-3. Wait for the probe to complete, indicated by 'Completed 1 of 1' appearing in the extension's output tab.
+1. Use the Extensions->BApp Store tab to install the 'HTTP Request Smuggler' extension.
+2. Load the lab homepage, find the request in the proxy history, right-click and select 'Extensions -> HTTP Request Smuggler -> Smuggle probe', then click 'OK'.
+3. Wait for the probe to complete, indicated by 'Completed request with key ...' appearing in the extension's output tab.
 4. If you're using Burp Suite Pro, find the reported vulnerability in the dashboard and open the first attached request.
 5. If you're using Burp Suite Community, copy the request from the output tab and paste it into the repeater, then complete the 'Target' details on the top right.
-6. Right click on the request and select 'Smuggle attack (CL.TE)'.
-7. Change the value of the 'prefix' variable to 'G', then click 'Attack' and confirm that one response says 'Unrecognised method GPOST'.
+6. Right-click on the request and select 'Extensions -> HTTP Request Smuggler -> Smuggle attack (CL.TE)'.
+7. Change the value of the 'prefix' variable to 'G', then click 'Attack' and confirm that one response says 'Unrecognized method GPOST'.
 
 By changing the 'prefix' variable in step 7, you can solve all the labs and virtually every real-world scenario.


### PR DESCRIPTION
- docs: Updated menu descriptions in README and BappDescription.html to match the latest version of Burp Suite (2023.11.1.3).
- chore: Removed the note about needing to include 'turbo-intruder-all.jar' since it is now included in the repository.
- fix: Corrected the jar file name in the compile instructions for manual installation.
