### PR TITLE
Added FOO technique from "The Single-Packet Shovel"

### DIFF
--- a/src/burp/HeadScanTE.java
+++ b/src/burp/HeadScanTE.java
@@ -46,6 +46,7 @@ public class HeadScanTE extends SmuggleScanBox implements IScannerCheck {
 
             //String foobar = "X\r\n\r\n";
             String foobar = "FOO BAR AAH\r\n\r\n";
+            String foo = "FOO\r\n\r\n";
 //            String foobar = "TRACE * HTTP/1.0\r\n\r\n";
 //            String originalReq = Utilities.helpers.bytesToString(Utilities.setMethod(Utilities.setPath(original, "/"), "GET"));
 
@@ -72,6 +73,7 @@ public class HeadScanTE extends SmuggleScanBox implements IScannerCheck {
 
                 ArrayList<String> attacks = new ArrayList<>();
                 attacks.add(foobar);
+                attacks.add(foo);
 //            attacks.put("invalid2", "GET / HTTP/1.2\r\nFoo: bar\r\n\r\n");
 //            attacks.put("unfinished", "GET / HTTP/1.1\r\nFoo: bar");
 


### PR DESCRIPTION
Hej!

Super small change, but this was initially what I used  to get smuggler to detect Tunnelling in a certain frontend / backend pair (where initially the detection was not working). Actual details pending a presentation later this week. 

In any case, there's always a chance this may work again, so I thought I'd submit it here as it's now known to have produced at least one real case. 

On a side-note, I just noticed `//String foobar = "X\r\n\r\n"` which may have worked in exactly the same way... regardless, the full `FOO` string was what I used in my testing.

Cheers,
Tom