### PR TITLE
Reduce Chunk Size Scanning False Positives with Backslash Technique

### DIFF
--- a/src/burp/ChunkSizeScan.java
+++ b/src/burp/ChunkSizeScan.java
@@ -264,18 +264,22 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {"\n", "\r"};
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildTwoOnePayload(baseReq, terminator);
+            PayloadPair testReq = buildTwoOnePayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout or unusual behavior
             if (response.timedOut()) {
                 Utilities.log("TWO.ONE potential vulnerability detected with terminator: " + 
                             terminator.replace("\n", "\\n").replace("\r", "\\r"));
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     // This suggests a parsing discrepancy
                     String title = "Possible HTTP Request Smuggling: TWO.ONE (Length-based Chunk Body)";
                     String description = "A timeout was observed when using line terminator '" + 
@@ -296,17 +300,21 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {""}; // Only empty string for ZERO.TWO
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildZeroTwoPayload(baseReq, terminator);
+            PayloadPair testReq = buildZeroTwoPayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout or unusual behavior
             if (response.timedOut()) {
                 Utilities.log("ZERO.TWO potential vulnerability detected with empty terminator");
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     // This suggests a parsing discrepancy
                     String title = "Possible HTTP Request Smuggling: ZERO.TWO (Length-based Chunk Body)";
                     String description = "A timeout was observed when using an empty line terminator in chunk bodies " +
@@ -326,17 +334,21 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {""}; // Only empty string for TWO.ZERO
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildTwoZeroPayload(baseReq, terminator);
+            PayloadPair testReq = buildTwoZeroPayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout or unusual behavior
             if (response.timedOut()) {
                 Utilities.log("TWO.ZERO potential vulnerability detected with empty terminator");
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     // This suggests a parsing discrepancy
                     String title = "Possible HTTP Request Smuggling: TWO.ZERO (Length-based Chunk Body)";
                     String description = "A timeout was observed when using an empty line terminator in chunk bodies " +
@@ -602,12 +614,13 @@ public class ChunkSizeScan extends Scan {
         return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
     }
     
-    private byte[] buildTwoOnePayload(byte[] baseReq, String lineTerminator) {
+    private PayloadPair buildTwoOnePayload(byte[] baseReq, String lineTerminator) {
         // Build the TWO.ONE payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        //该情况下，前端实际能够携带的chunk body数据天然比后端少一位，无法满足后端倒转所需要的字节数，因此该场景先不做逆转分析
+        //In this scenario, the chunk body data the frontend can carry is naturally an order of magnitude smaller than the backend's.
+        // We have no choice but to ignore 0\r\n\r\n for direct testing, which at least filters out certain special endpoints.
         // TWO.ONE payload structure:
         // 2\r\n
         // XX{line_terminator}
@@ -617,29 +630,36 @@ public class ChunkSizeScan extends Scan {
         // 0\r\n
         // \r\n
         
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("2\r\n");
-        payload.append("XX").append(lineTerminator);
-        payload.append("10\r\n");
-        payload.append("\r\n");
-        payload.append("AAAABBBBCCCCDD\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        
-        return payload.toString().getBytes();
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("2\r\n");
+        forward.append("XX").append(lineTerminator);
+        forward.append("10\r\n");
+        forward.append("\r\n");
+        forward.append("AAAABBBBCCCCDD\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
     }
     
-    private byte[] buildZeroTwoPayload(byte[] baseReq, String lineTerminator) {
+    private PayloadPair buildZeroTwoPayload(byte[] baseReq, String lineTerminator) {
         // Build the ZERO.TWO payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        //lineTerminator 为空字符串，不存在lineTerminator引起的timeout
+        //Given that lineTerminator is an empty string , we will use 0\r\n\r\n for direct verification.
         // ZERO.TWO payload structure:
         // 2\r\n
         // XX{line_terminator}
@@ -653,33 +673,41 @@ public class ChunkSizeScan extends Scan {
         // 0\r\n
         // \r\n
         
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("2\r\n");
-        payload.append("XX").append(lineTerminator);
-        payload.append("012\r\n");
-        payload.append("XX\r\n");
-        payload.append("19\r\n");
-        payload.append("XXAAAABBBB\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        payload.append("CCCCDDDD\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("2\r\n");
+        forward.append("XX").append(lineTerminator);
+        forward.append("012\r\n");
+        forward.append("XX\r\n");
+        forward.append("19\r\n");
+        forward.append("XXAAAABBBB\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        forward.append("CCCCDDDD\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
         
-        return payload.toString().getBytes();
     }
     
-    private byte[] buildTwoZeroPayload(byte[] baseReq, String lineTerminator) {
+    private PayloadPair buildTwoZeroPayload(byte[] baseReq, String lineTerminator) {
         // Build the TWO.ZERO payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        //lineTerminator 为空字符串，不存在lineTerminator引起的timeout
+        //Given that lineTerminator is an empty string , we will use 0\r\n\r\n for direct verification.
         // TWO.ZERO payload structure:
         // 2\r\n
         // xx{line_terminator}
@@ -689,21 +717,29 @@ public class ChunkSizeScan extends Scan {
         // 0\r\n
         // \r\n
         
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("2\r\n");
-        payload.append("xx").append(lineTerminator);
-        payload.append("010\r\n");
-        payload.append("\r\n");
-        payload.append("AAAABBBBCCCCDD\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        
-        return payload.toString().getBytes();
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("2\r\n");
+        forward.append("xx").append(lineTerminator);
+        forward.append("010\r\n");
+        forward.append("\r\n");
+        forward.append("AAAABBBBCCCCDD\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
     }
     
     private byte[] buildNormalGetRequest(IHttpService service) {

--- a/src/burp/ChunkSizeScan.java
+++ b/src/burp/ChunkSizeScan.java
@@ -84,18 +84,22 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {"\n", "\r", "\rX", "\r\r"};
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildTermExtPayload(baseReq, terminator);
+            PayloadPair testReq = buildTermExtPayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout
             if (response.timedOut()) {
                 Utilities.log("TERM.EXT potential vulnerability detected with terminator: " + 
                             terminator.replace("\n", "\\n").replace("\r", "\\r"));
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     String title = "Possible HTTP Request Smuggling: TERM.EXT (Chunk Extension Parsing)";
                     String description = "A timeout was observed when using line terminator '" + 
                                        terminator.replace("\n", "\\n").replace("\r", "\\r") + 
@@ -115,18 +119,22 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {"\n", "\r", "\rX", "\r\r"};
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildExtTermPayload(baseReq, terminator);
+            PayloadPair testReq = buildExtTermPayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout or unusual behavior
             if (response.timedOut()) {
                 Utilities.log("EXT.TERM potential vulnerability detected with terminator: " + 
                             terminator.replace("\n", "\\n").replace("\r", "\\r"));
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     // This suggests a parsing discrepancy
                     String title = "Possible HTTP Request Smuggling: EXT.TERM (Chunk Extension Parsing)";
                     String description = "A timeout was observed when using line terminator '" + 
@@ -147,18 +155,22 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {"\n", "\r", "", "XX", "\rX", "\r\r"};
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildTermSpillPayload(baseReq, terminator);
+            PayloadPair testReq = buildTermSpillPayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout or unusual behavior
             if (response.timedOut()) {
                 Utilities.log("TERM.SPILL potential vulnerability detected with terminator: " + 
                             terminator.replace("\n", "\\n").replace("\r", "\\r"));
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     // This suggests a parsing discrepancy
                     String title = "Possible HTTP Request Smuggling: TERM.SPILL (Terminator Spill)";
                     String description = "A timeout was observed when using line terminator '" + 
@@ -179,18 +191,22 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {"\n", "\r", "", "XX", "\rX", "\r\r"};
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildSpillTermPayload(baseReq, terminator);
+            PayloadPair testReq = buildSpillTermPayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout or unusual behavior
             if (response.timedOut()) {
                 Utilities.log("SPILL.TERM potential vulnerability detected with terminator: " + 
                             terminator.replace("\n", "\\n").replace("\r", "\\r"));
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     // This suggests a parsing discrepancy
                     String title = "Possible HTTP Request Smuggling: SPILL.TERM (Spill Terminator)";
                     String description = "A timeout was observed when using line terminator '" + 
@@ -211,18 +227,23 @@ public class ChunkSizeScan extends Scan {
         String[] lineTerminators = {"\n", "\r"};
         
         for (String terminator : lineTerminators) {
-            byte[] testReq = buildOneTwoPayload(baseReq, terminator);
+            PayloadPair testReq = buildOneTwoPayload(baseReq, terminator);
             
             // Send the request
-            Resp response = request(service, testReq, 0, true);
+            Resp response = request(service, testReq.forward, 0, true);
             
             // Check for timeout or unusual behavior
             if (response.timedOut()) {
                 Utilities.log("ONE.TWO potential vulnerability detected with terminator: " + 
                             terminator.replace("\n", "\\n").replace("\r", "\\r"));
-                
+                //add invert check
+                Resp respInverted = request(service, testReq.inverted, 0, true);
+                if (respInverted.timedOut()){
+                    return;
+                }
+
                 // Confirm with 5 repeated requests
-                if (confirmWithRepeats(testReq, service, terminator)) {
+                if (confirmWithRepeats(testReq.forward, service, terminator)) {
                     // This suggests a parsing discrepancy
                     String title = "Possible HTTP Request Smuggling: ONE.TWO (Length-based Chunk Body)";
                     String description = "A timeout was observed when using line terminator '" + 
@@ -330,191 +351,255 @@ public class ChunkSizeScan extends Scan {
             }
         }
     }
-    
-    private byte[] buildTermExtPayload(byte[] baseReq, String lineTerminator) {
+
+    private PayloadPair buildTermExtPayload(byte[] baseReq, String lineTerminator) {
         // Build the TERM.EXT payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
-        // TERM.EXT payload structure:
-        // 2;{line_terminator}XX\r\n
-        // 10\r\n
-        // 1f\r\n
-        // AAAABBBBCCCC\r\n
-        // 0\r\n
-        // \r\n
+
+        // Build the TERM.EXT payload based on smugchunks implementation
+        // TERM.EXT payload structure:          inverted :
+        // 2;{line_terminator}XX\r\n            2;{line_terminator}XX\r\n
+        // 10\r\n                               14\r\n
+        // 1f\r\n                               10\r\n
+        // AAAABBBBCCCC\r\n                     AAAABBBBCCCCDDDD\r\n
+        // 0\r\n                                0\r\n
+        // \r\n                                 \r\n
         // DDDDEEEEFFFF\r\n
         // 0\r\n
         // \r\n
-        
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("2;").append(lineTerminator).append("XX\r\n");
-        payload.append("10\r\n");
-        payload.append("1f\r\n");
-        payload.append("AAAABBBBCCCC\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        payload.append("DDDDEEEEFFFF\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        
-        return payload.toString().getBytes();
-    }
-    
 
-    
-    private byte[] buildExtTermPayload(byte[] baseReq, String lineTerminator) {
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("2;").append(lineTerminator).append("XX\r\n");
+        forward.append("10\r\n");
+        forward.append("1f\r\n");
+        forward.append("AAAABBBBCCCC\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        forward.append("DDDDEEEEFFFF\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("2;").append(lineTerminator).append("XX\r\n");
+        inverted.append("14\r\n");
+        inverted.append("10\r\n");
+        inverted.append("AAAABBBBCCCCDDDD\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
+    }
+
+
+
+    private PayloadPair buildExtTermPayload(byte[] baseReq, String lineTerminator) {
         // Build the EXT.TERM payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
-        // EXT.TERM payload structure:
-        // 2;{line_terminator}XX\r\n
-        // 22\r\n
-        // c\r\n
-        // AAAABBBBCCCC\r\n
-        // 0\r\n
-        // \r\n
+
+        // Build the EXT.TERM payload based on smugchunks implementation
+        // EXT.TERM payload structure:          invert ：
+        // 2;{line_terminator}XX\r\n            2;{line_terminator}XX\r\n
+        // 22\r\n                               10\r\n
+        // c\r\n                                d\r\n
+        // AAAABBBBCCCC\r\n                     AAAABBBBCCCCD\r\n
+        // 0\r\n                                0\r\n
+        // \r\n                                 \r\n
         // DDDDEEEEFFFF\r\n
         // 0\r\n
         // \r\n
-        
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("2;").append(lineTerminator).append("XX\r\n");
-        payload.append("22\r\n");
-        payload.append("c\r\n");
-        payload.append("AAAABBBBCCCC\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        payload.append("DDDDEEEEFFFF\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        
-        return payload.toString().getBytes();
+
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("2;").append(lineTerminator).append("XX\r\n");
+        forward.append("22\r\n");
+        forward.append("c\r\n");
+        forward.append("AAAABBBBCCCC\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        forward.append("DDDDEEEEFFFF\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("2;").append(lineTerminator).append("XX\r\n");
+        inverted.append("10\r\n");
+        inverted.append("d\r\n");
+        inverted.append("AAAABBBBCCCCD\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
     }
-    
-    private byte[] buildTermSpillPayload(byte[] baseReq, String lineTerminator) {
+
+    private PayloadPair buildTermSpillPayload(byte[] baseReq, String lineTerminator) {
         // Build the TERM.SPILL payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
-        // TERM.SPILL payload structure:
-        // 5\r\n
-        // AAAAA{line_terminator}c\r\n
-        // 17\r\n
-        // AAAABBBB\r\n
-        // 0\r\n
-        // \r\n
+
+        // TERM.SPILL payload structure:              inverted:
+        // 5\r\n                                      5\r\n
+        // AAAAA{line_terminator}c\r\n                AAAAA{line_terminator}c\r\n
+        // 17\r\n                                     9\r\n
+        // AAAABBBB\r\n                               AAAABBBBC\r\n
+        // 0\r\n                                      0\r\n
+        // \r\n                                       \r\n
         // CCCCDDDD\r\n
         // 0\r\n
         // \r\n
-        
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("5\r\n");
-        payload.append("AAAAA").append(lineTerminator).append("c\r\n");
-        payload.append("17\r\n");
-        payload.append("AAAABBBB\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        payload.append("CCCCDDDD\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        
-        return payload.toString().getBytes();
+
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("5\r\n");
+        forward.append("AAAAA").append(lineTerminator).append("c\r\n");
+        forward.append("17\r\n");
+        forward.append("AAAABBBB\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        forward.append("CCCCDDDD\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("5\r\n");
+        inverted.append("AAAAA").append(lineTerminator).append("c\r\n");
+        inverted.append("9\r\n");
+        inverted.append("AAAABBBBC\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
     }
     
-    private byte[] buildSpillTermPayload(byte[] baseReq, String lineTerminator) {
+    private PayloadPair buildSpillTermPayload(byte[] baseReq, String lineTerminator) {
         // Build the SPILL.TERM payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
-        // SPILL.TERM payload structure:
-        // 5\r\n
-        // AAAAA{line_terminator}1a\r\n
-        // 8\r\n
-        // AAAABBBB\r\n
-        // 0\r\n
-        // \r\n
+
+        // SPILL.TERM payload structure:         inverted:
+        // 5\r\n                                 5\r\n
+        // AAAAA{line_terminator}1a\r\n          AAAAA{line_terminator}b\r\n
+        // 8\r\n                                 8\r\n
+        // AAAABBBB\r\n                          AAAABBBB\r\n
+        // 0\r\n                                 0\r\n
+        // \r\n                                  \r\n
         // CCCCDDDD\r\n
         // 0\r\n
         // \r\n
         
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("5\r\n");
-        payload.append("AAAAA").append(lineTerminator).append("1a\r\n");
-        payload.append("8\r\n");
-        payload.append("AAAABBBB\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        payload.append("CCCCDDDD\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        
-        return payload.toString().getBytes();
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("5\r\n");
+        forward.append("AAAAA").append(lineTerminator).append("1a\r\n");
+        forward.append("8\r\n");
+        forward.append("AAAABBBB\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        forward.append("CCCCDDDD\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("5\r\n");
+        inverted.append("AAAAA").append(lineTerminator).append("b\r\n");
+        inverted.append("8\r\n");
+        inverted.append("AAAABBBB\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
     }
     
-    private byte[] buildOneTwoPayload(byte[] baseReq, String lineTerminator) {
+    private PayloadPair buildOneTwoPayload(byte[] baseReq, String lineTerminator) {
         // Build the ONE.TWO payload based on smugchunks implementation
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
-        // ONE.TWO payload structure:
-        // 2\r\n
-        // XX{line_terminator}
-        // 12\r\n
-        // XX\r\n
-        // 19\r\n
-        // XXAAAABBBB\r\n
-        // 0\r\n
+
+        // ONE.TWO payload structure:           inverted:
+        // 2\r\n                                2\r\n
+        // XX{line_terminator}                  XX{line_terminator}
+        // 12\r\n                               12\r\n
+        // XX\r\n                               XX\r\n
+        // 19\r\n                               b\r\n
+        // XXAAAABBBB\r\n                       XXXAAAABBBB\r\n
+        // 0\r\n                                0\r\n
         // \r\n
         // CCCCDDDD\r\n
         // 0\r\n
         // \r\n
         
-        StringBuilder payload = new StringBuilder();
-        payload.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
-        payload.append("Host: ").append(host).append("\r\n");
-        payload.append("Transfer-Encoding: chunked\r\n");
-        payload.append("Connection: close\r\n");
-        payload.append("\r\n");
-        payload.append("2\r\n");
-        payload.append("XX").append(lineTerminator);
-        payload.append("12\r\n");
-        payload.append("XX\r\n");
-        payload.append("19\r\n");
-        payload.append("XXAAAABBBB\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        payload.append("CCCCDDDD\r\n");
-        payload.append("0\r\n");
-        payload.append("\r\n");
-        
-        return payload.toString().getBytes();
+        StringBuilder forward = new StringBuilder();
+        forward.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        forward.append("Host: ").append(host).append("\r\n");
+        forward.append("Transfer-Encoding: chunked\r\n");
+        forward.append("Connection: close\r\n");
+        forward.append("\r\n");
+        forward.append("2\r\n");
+        forward.append("XX").append(lineTerminator);
+        forward.append("12\r\n");
+        forward.append("XX\r\n");
+        forward.append("19\r\n");
+        forward.append("XXAAAABBBB\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+        forward.append("CCCCDDDD\r\n");
+        forward.append("0\r\n");
+        forward.append("\r\n");
+
+        StringBuilder inverted = new StringBuilder();
+        inverted.append(method).append(" ").append(path).append(" HTTP/1.1\r\n");
+        inverted.append("Host: ").append(host).append("\r\n");
+        inverted.append("Transfer-Encoding: chunked\r\n");
+        inverted.append("Connection: close\r\n");
+        inverted.append("\r\n");
+        inverted.append("2\r\n");
+        inverted.append("XX").append(lineTerminator);
+        inverted.append("12\r\n");
+        inverted.append("XX\r\n");
+        inverted.append("b\r\n");
+        inverted.append("XXXAAAABBBB\r\n");
+        inverted.append("0\r\n");
+        inverted.append("\r\n");
+        return new PayloadPair(forward.toString().getBytes(), inverted.toString().getBytes());
     }
     
     private byte[] buildTwoOnePayload(byte[] baseReq, String lineTerminator) {
@@ -522,7 +607,7 @@ public class ChunkSizeScan extends Scan {
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
+        //该情况下，前端实际能够携带的chunk body数据天然比后端少一位，无法满足后端倒转所需要的字节数，因此该场景先不做逆转分析
         // TWO.ONE payload structure:
         // 2\r\n
         // XX{line_terminator}
@@ -554,7 +639,7 @@ public class ChunkSizeScan extends Scan {
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
+        //lineTerminator 为空字符串，不存在lineTerminator引起的timeout
         // ZERO.TWO payload structure:
         // 2\r\n
         // XX{line_terminator}
@@ -594,7 +679,7 @@ public class ChunkSizeScan extends Scan {
         String host = Utilities.getHeader(baseReq, "Host");
         String path = Utilities.getPathFromRequest(baseReq);
         String method = Utilities.getMethod(baseReq);
-        
+        //lineTerminator 为空字符串，不存在lineTerminator引起的timeout
         // TWO.ZERO payload structure:
         // 2\r\n
         // xx{line_terminator}
@@ -634,5 +719,13 @@ public class ChunkSizeScan extends Scan {
         payload.append("\r\n");
         
         return payload.toString().getBytes();
+    }
+    static class PayloadPair {
+        private final byte[] forward;
+        private final byte[] inverted;
+        public PayloadPair(byte[] forward,byte[] inverted){
+            this.forward = forward;
+            this.inverted = inverted;
+        }
     }
 } 


### PR DESCRIPTION
## Problem

The chunk size scanning plugin in http-request-smuggler generates a high volume of false positives, even with 5 retry attempts.

## Root Cause

Upon investigation, the issue appears to stem from malformed chunk size formats. For example, chunk line terminators containing only CR or LF are inherently prone to causing timeouts. Certain special hosts may even produce timeouts for legitimate POST requests.

## Solution

To minimize false positives from chunk size detection, I introduced an **inverted payload** as a backslash (baseline/control) test. This uses orthogonal and cross-validation testing to reduce the likelihood of line terminator-related false positives.

An **inverted payload** is one that, when parsed according to the semantic rules of the target vulnerability (e.g., Term.Ext), should **not** produce a timeout.

### Example: Term.Ext

```
// TERM.EXT                             INVERTED:
// 2;{line_terminator}XX\r\n            2;{line_terminator}XX\r\n
// 10\r\n                               14\r\n
// 1f\r\n                               10\r\n
// AAAABBBBCCCC\r\n                     AAAABBBBCCCCDDDD\r\n
// 0\r\n                                0\r\n
// \r\n                                 \r\n
// DDDDEEEEFFFF\r\n
// 0\r\n
// \r\n
```

#### Parsing Logic

| Frontend | Backend |
|----------|---------|
| `2` **// line_terminator** | `2;{line_terminator}XX` **// EXT** |
| `XX` // chunk 1 end | `14` // chunk 1 end |
| `14` | `10` |
| `10\r\nAAAABBBBCCCCDDDD` // chunk 2 end | `AAAABBBBCCCCDDDD` // chunk 2 end |
| `0\r\n` | `0\r\n` |
| `\r\n` | `\r\n` |

### Affected Attack Types

The inverted payload technique is applied to the following attack types:

- `term.ext`
- `ext.term`
- `term.spill`
- `spill.term`
- `one.two`

### Special Cases

#### two.one

In this scenario, the chunk body data the frontend can carry is naturally an order of magnitude smaller than the backend's. We bypass `0\r\n\r\n` for direct testing, which at least filters out certain special endpoints.

#### zero.two & two.zero

Given that `lineTerminator` is an empty string, we use `0\r\n\r\n` for direct verification.
